### PR TITLE
[feat] Swagger 설정 및 API 명세 페이지 구현 closes #8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 
-    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
-    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nes/tireso/base/swagger/SwaggerConfig.java
+++ b/src/main/java/com/nes/tireso/base/swagger/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.nes.tireso.base.swagger;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@PropertySource("classpath:application.yml")
+@OpenAPIDefinition(
+		info = @Info(title = "TIRE,SO. WEB",
+				description = "TIRE,SO. WEB API 명세",
+				version = "v1")
+)
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public GroupedOpenApi OpenApi() {
+		String[] paths = {"/**"};
+
+		return GroupedOpenApi.builder()
+				.group("TIRE,SO. API v1")
+				.pathsToMatch(paths)
+				.build();
+	}
+}

--- a/src/main/java/com/nes/tireso/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/nes/tireso/boundedContext/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.nes.tireso.boundedContext.member.service.MemberService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 
 @Controller
@@ -19,6 +20,7 @@ public class MemberController {
 
 	@PreAuthorize("isAnonymous()")
 	@GetMapping("/login")
+	@Operation(summary = "OAuth 로그인 예시 API", description = "카카오, 구글, 네이버 OAuth 로그인 예시를 위한 API입니다.")
 	public String showLogin() {
 		return "usr/member/login";
 	}


### PR DESCRIPTION
### Related Issue
- #8 

### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

클라이언트와 통신하기 위한 API 명세서가 필요하다고 판단하였음

### Problem Solving

Swagger를 도입하여 API 명세서를 보다 간편하게 생성하도록 함

### Result

![image](https://user-images.githubusercontent.com/68031450/260098073-ff5d552d-9d2c-4f72-877d-c30f49c1a04a.png)

### To Reviewer

❗️아래 내용들 읽어보시면 좋을 것 같습니다

- API 문서화를 왜 해야할까? : [https://jinlee1703.github.io/web/2023-06-01-api-documentation-automation/](https://jinlee1703.github.io/web/2023-06-01-api-documentation-automation/)
- Swagger 2.0에서 3.0으로 변경되면서 달라진 설정 : [https://jinlee1703.github.io/web/2023-06-01-swagger_version_error/](https://jinlee1703.github.io/web/2023-06-01-swagger_version_error/)