### PR TITLE
[feat] 로그인 API 에서 필요한 회원 정보 가져오기 closes #15

### DIFF
--- a/src/main/java/com/nes/tireso/boundedContext/home/controller/HomeController.java
+++ b/src/main/java/com/nes/tireso/boundedContext/home/controller/HomeController.java
@@ -1,34 +1,24 @@
 package com.nes.tireso.boundedContext.home.controller;
 
-import java.nio.charset.Charset;
-
+import com.nes.tireso.base.rq.Rq;
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.nes.tireso.base.rq.Rq;
 
 @RestController
 @RequiredArgsConstructor
 public class HomeController {
-	// private final Rq rq;
-	//
-	// @GetMapping("/")
-	// public String showMain() {
-	// 	if (rq.isLogout()) return "redirect:/usr/member/login";
-	//
-	// 	return "redirect:/usr/member/me";
-	// }
+    private final Rq rq;
 
-	@GetMapping("/hello")
-	public ResponseEntity<String> hello() {
-		return new ResponseEntity<String>("hello", HttpStatus.OK);
-	}
+    @GetMapping("/")
+    public String showMain() {
+        if (!rq.isLogout()) return "redirect:/usr/member/me"; // 로그아웃이 아닌 경우에 리다이렉트
+        return "redirect:/usr/member/login"; // 로그아웃인 경우에 리다이렉트
+    }
+
+
+    //@GetMapping("/hello")
+    //public ResponseEntity<String> hello() {
+    //	return new ResponseEntity<String>("hello", HttpStatus.OK);
+    //}
 }

--- a/src/main/java/com/nes/tireso/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/nes/tireso/boundedContext/member/entity/Member.java
@@ -1,13 +1,6 @@
 package com.nes.tireso.boundedContext.member.entity;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-
 import com.nes.tireso.base.baseEntity.BaseEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.Builder;
@@ -15,6 +8,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,42 +20,70 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @ToString(callSuper = true)
 public class Member extends BaseEntity {
-	private String providerTypeCode;
-	@Column(unique = true)
-	private String username;
-	private String name;
-	private String password;
-	private String carType;
-	private String type;
-	private String width;
-	private String ratio;
+    private String providerTypeCode;
+    @Column(unique = true)
+    private String username;
+    private String nickname;
+    private String password;
+    private String email;
+    private String profileImage;
+    private String carType;
+    private String type;
+    private String width;
+    private String ratio;
 
-	public List<? extends GrantedAuthority> getGrantedAuthorities() {
-		List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+    public List<? extends GrantedAuthority> getGrantedAuthorities() {
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
 
-		grantedAuthorities.add(new SimpleGrantedAuthority("member"));
+        grantedAuthorities.add(new SimpleGrantedAuthority("member"));
 
-		if (isAdmin()) {
-			grantedAuthorities.add(new SimpleGrantedAuthority("admin"));
-		}
+        if (isAdmin()) {
+            grantedAuthorities.add(new SimpleGrantedAuthority("admin"));
+        }
 
-		return grantedAuthorities;
-	}
+        return grantedAuthorities;
+    }
 
-	public boolean isAdmin() {
-		return "admin".equals(username);
-	}
+    public boolean isAdmin() {
+        return "admin".equals(username);
+    }
 
-	@Builder
-	public Member(String providerTypeCode, String username, String name, String password, String carType, String type,
-			String width, String ratio) {
-		this.providerTypeCode = providerTypeCode;
-		this.username = username;
-		this.name = name;
-		this.password = password;
-		this.carType = carType;
-		this.type = type;
-		this.width = width;
-		this.ratio = ratio;
-	}
+    @Builder
+    public Member(String providerTypeCode, String username, String nickname, String password, String email,
+                  String profileImage, String carType, String type, String width, String ratio) {
+        this.providerTypeCode = providerTypeCode;
+        this.username = username;
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.carType = carType;
+        this.type = type;
+        this.width = width;
+        this.ratio = ratio;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+
+    public String getEmail() {
+        return email;
+    }
 }

--- a/src/main/java/com/nes/tireso/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/nes/tireso/boundedContext/member/service/MemberService.java
@@ -1,56 +1,59 @@
 package com.nes.tireso.boundedContext.member.service;
 
-
-import java.util.Optional;
-
+import com.nes.tireso.base.rsData.RsData;
+import com.nes.tireso.boundedContext.member.entity.Member;
+import com.nes.tireso.boundedContext.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import com.nes.tireso.base.rsData.RsData;
-import com.nes.tireso.boundedContext.member.entity.Member;
-import com.nes.tireso.boundedContext.member.repository.MemberRepository;
-
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
-	private final PasswordEncoder passwordEncoder;
-	private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
 
-	public Optional<Member> findByUsername(String username) {
-		return memberRepository.findByUsername(username);
-	}
+    public Optional<Member> findByUsername(String username) {
+        return memberRepository.findByUsername(username);
+    }
 
-	private RsData<Member> join(String providerTypeCode, String username, String password) {
-		if (findByUsername(username).isPresent()) {
-			return RsData.of("F-1", "해당 아이디(%s)는 이미 사용중입니다.".formatted(username));
-		}
+    private RsData<Member> join(String providerTypeCode, String username, String password, String nickname, String profileImage, String email) {
+        if (findByUsername(username).isPresent()) {
+            return RsData.of("F-1", "해당 아이디(%s)는 이미 사용중입니다.".formatted(username));
+        }
 
-		if (StringUtils.hasText(password)) {
-			password = passwordEncoder.encode(password);
-		}
+        if (StringUtils.hasText(password)) {
+            password = passwordEncoder.encode(password);
+        }
 
-		Member member = Member.builder()
-			.providerTypeCode(providerTypeCode)
-			.username(username)
-			.password(password)
-			.build();
+        Member member = Member.builder()
+                .providerTypeCode(providerTypeCode)
+                .username(username)
+                .password(password)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .email(email)
+                .build();
 
-		memberRepository.save(member);
+        memberRepository.save(member);
 
-		return RsData.of("S-1", "회원가입이 완료되었습니다.", member);
-	}
+        return RsData.of("S-1", "회원가입이 완료되었습니다.", member);
+    }
 
-	@Transactional
-	public RsData<Member> whenSocialLogin(String providerTypeCode, String username) {
-		Optional<Member> opMember = findByUsername(username);
+    @Transactional
+    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String nickname, String profileImage, String email) {
+        Optional<Member> opMember = findByUsername(username);
 
-		return opMember.map(member -> RsData.of("S-2", "로그인 되었습니다.", member))
-			.orElseGet(() -> join(providerTypeCode, username, ""));
-
-	}
+        return opMember.map(member -> {
+            member.setNickname(nickname);
+            member.setProfileImage(profileImage);
+            member.setEmail(email);
+            return RsData.of("S-2", "로그인 되었습니다.", member);
+        }).orElseGet(() -> join(providerTypeCode, username, "", nickname, profileImage, email));
+    }
 }


### PR DESCRIPTION
### Related Issue
- #15 

### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
마이페이지에서 나의 정보(닉네임, 이메일, 프로필 사진)을 확인할 수 있다.

### Problem Solving
1. 네이버만 로그인이 안되는 문제
  - Callback URL 설정을 잘 해놓자!

2. 구글, 네이버에서 정보가 가져와지지 않는 문제
  - 네이버는 response 속에.. 구글은 그냥.. 카카오는 properties, kakao_account 속에 있었다고 한다.
  - 어디에 뭐가 있는지 몰라서 구글링 열심히 해서 해결했다!

### To Reviewer
제가 깜빡하고 이슈 번호를 안 달았네요 .. ㅎㅎㅎㅎ 🙏🏻🙏🏻
